### PR TITLE
Bug: Is callable states true for strings such as Class\Name::method

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -37,8 +37,13 @@ class Dispatcher
                 sprintf("The route %s doesn't have an action to dispatch", $route->name)
             );
         }
+
         if (is_callable($route->params['action'])) {
-            return $route->params['action']($request, $response, $next);
+            return call_user_func_array($route->params['action'], array(
+                $request,
+                $response,
+                $next,
+            ));
         } elseif (is_string($route->params['action'])) {
             $action = new $route->params['action'];
             if (is_callable($action)) {

--- a/test/DispatchTest.php
+++ b/test/DispatchTest.php
@@ -64,4 +64,16 @@ class DispatcherTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testDispatchCallableStringClassMethodAction()
+    {
+        $this->router->add('myclass', '/')
+                     ->addValues([ 'action' => 'ZendTest\Stratigility\Dispatch\TestAsset\ClassMethod::myMethod' ]);
+
+        $dispatch = new Dispatcher($this->router);
+        $this->request = $this->request->withUri(new Uri('/'));
+        $result = $dispatch($this->request, $this->response, function(){});
+
+        $this->assertTrue($result);
+    }
 }

--- a/test/TestAsset/ClassMethod.php
+++ b/test/TestAsset/ClassMethod.php
@@ -1,0 +1,13 @@
+<?php
+namespace ZendTest\Stratigility\Dispatch\TestAsset;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ClassMethod
+{
+    public static function MyMethod(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## Overview

When using is_callable, this will state true for things such as Class\Name::method which will attempt to invoke a static method of Class\Name.   Currently since it is attempting to simply invoke the action as a function this causes an issue and a bug as seen in the current test suite.
## Implementation

Instead of attempting to invoke the action directly, utilizing call_user_func_array will resolve the issue.
