### PR TITLE
Aura Router: Added the ability for group routes

### DIFF
--- a/src/MiddlewareDispatch.php
+++ b/src/MiddlewareDispatch.php
@@ -49,17 +49,33 @@ class MiddlewareDispatch
                 sprintf("The routes part is missing in the configuration")
             );
         }
-        foreach ($config['routes'] as $name => $data) {
-            if (!isset($data['action'])) {
-                throw new Exception\InvalidArgumentException(
-                    sprintf("The action parameter is missing in route %s", $name)
-                );
-            }
-            if (!isset($data['url'])) {
-                throw new Exception\InvalidArgumentException(
-                    sprintf("The url parameter is missing in route %s", $name)
-                );
-            }
+
+        array_walk($config['routes'], 'self::checkRoutes');
+    }
+
+    /**
+     * Check routes from configuration
+     *
+     * @param  array  $data
+     * @param  string $name
+     * @throws Exception\InvalidArgumentException
+     */
+    protected static function checkRoutes(array $data, $name)
+    {
+        if (!isset($data['url'])) {
+            throw new Exception\InvalidArgumentException(
+                sprintf("The url parameter is missing in route %s", $name)
+            );
+        }
+
+        if (isset($data['children'])) {
+            return array_walk($data['children'], 'self::checkRoutes');
+        }
+
+        if (!isset($data['action'])) {
+            throw new Exception\InvalidArgumentException(
+                sprintf("The action parameter is missing in route %s", $name)
+            );
         }
     }
 }

--- a/src/Router/Aura.php
+++ b/src/Router/Aura.php
@@ -65,7 +65,33 @@ class Aura implements RouterInterface
         if (!empty($this->config)) {
             $this->createRouter();
         }
+
         foreach ($config['routes'] as $name => $data) {
+            if (isset($data['children'])) {
+                $this->router->attach($name, $data['url'], function ($router) use ($data) {
+                    if (isset($data['tokens'])) {
+                        $router->addTokens($data['tokens']);
+                    }
+                    if (isset($data['values'])) {
+                        $router->addValues($data['values']);
+                    }
+
+                    foreach ($data['children'] as $name => $data) {
+                        $data['values'] = isset($data['values']) ? $data['values'] : [];
+                        $data['values']['action'] = $data['action'];
+
+                        $route = $router->add($name, $data['url']);
+                        $route->addValues($data['values']);
+
+                        if (isset($data['tokens'])) {
+                            $route->addTokens($data['tokens']);
+                        }
+                    }
+                });
+
+                continue ;
+            }
+
             $this->router->add($name, $data['url']);
             if (!isset($data['values'])) {
                 $data['values'] = [];

--- a/test/MiddlewareDispatchTest.php
+++ b/test/MiddlewareDispatchTest.php
@@ -80,4 +80,22 @@ class MiddlewareDispatchTest extends TestCase
         $this->assertTrue($dispatcher($request, $response, function () {
         }));
     }
+
+    public function testRoutingChildrenRoute()
+    {
+        $dispatcher = MiddlewareDispatch::factory($this->config);
+
+        $request  = new ServerRequest();
+        $request  = $request->withUri(new Uri('/children/'));
+        $response = new Response();
+
+        $this->assertTrue($dispatcher($request, $response, function () {
+        }));
+
+        $request  = $request->withUri(new Uri('/children/page'));
+        $response = new Response();
+
+        $this->assertTrue($dispatcher($request, $response, function () {
+        }));
+    }
 }

--- a/test/TestAsset/config.php
+++ b/test/TestAsset/config.php
@@ -21,14 +21,32 @@ return [
         // example of action class using optional parameter in the URL
         // the syntax of the URL and the tokens depend on the router adapter (Aura in this case)
         'search' => [
-              'url'    => '/search{/query}',
-              'tokens' => [ 'query' => '([^/]+)?' ],
-              'action' => 'ZendTest\Stratigility\Dispatch\TestAsset\Search'
+            'url'    => '/search{/query}',
+            'tokens' => [ 'query' => '([^/]+)?' ],
+            'action' => 'ZendTest\Stratigility\Dispatch\TestAsset\Search'
         ],
         // example of object call from a container
         'test' => [
-              'url'    => '/test',
-              'action' => 'ObjectFromContainer'
-        ]
+            'url'    => '/test',
+            'action' => 'ObjectFromContainer'
+        ],
+        // example of children routing
+        'children' => [
+            'url' => '/children',
+            'children' => [
+                'home' => [
+                    'url' => '/',
+                    'action' => 'ZendTest\Stratigility\Dispatch\TestAsset\Home'
+                ],
+                'page' => [
+                    'url' => '/page',
+                    'action' => function ($request, $response, $next) {
+                        $bar  = new ZendTest\Stratigility\Dispatch\TestAsset\Bar();
+                        $page = new ZendTest\Stratigility\Dispatch\TestAsset\Page($bar);
+                        return $page->action($request, $response, $next);
+                    }
+                ],
+            ],
+        ],
     ]
 ];


### PR DESCRIPTION
## Overview

Aura Router has the ability for [Attaching Route Groups](https://github.com/auraphp/Aura.Router#attaching-route-groups).  This PR adds support for the route groups and updates the configuration checking.  At this point I do have concerns over the configuration handling that we have today as I do believe that it might need some updates (however, I will mention that in another ticket).
## Implementation

The ability for child routes simply changes the way that we presently handle routes by adding in a **children** associative index to the array.  This is checked and then it will push it through.  The implementation does cause some slight duplication, however, not enough to refactor it out significantly.
